### PR TITLE
Private attributes starts with '__', not with '_'

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -67,18 +67,18 @@ function generateGetterSetterMethods(pythonCode) {
         // eslint-disable-next-line no-unused-vars
         const [attribute, value] = line.split('=').map((str) => str.trim());
         const attributeName = attribute.split('.')[1];
-		
-		if (attributeName.startsWith('_')) {
+  
+		if (attributeName.startsWith('__')) {
 			const getterMethod = `
     @property
-    def ${attributeName.slice(1)}(self):
+    def ${attributeName.slice(2)}(self):
         return self.${attributeName}
 `;
 		generatedCode += getterMethod;
 
 		const setterMethod = `
-    @${attributeName.slice(1)}.setter
-    def ${attributeName.slice(1)}(self, value):
+    @${attributeName.slice(2)}.setter
+    def ${attributeName.slice(2)}(self, value):
         self.${attributeName} = value
 `;
 		generatedCode += setterMethod;

--- a/extension.js
+++ b/extension.js
@@ -78,8 +78,8 @@ function generateGetterSetterMethods(pythonCode) {
 
 		const setterMethod = `
     @${attributeName.slice(2)}.setter
-    def ${attributeName.slice(2)}(self, value):
-        self.${attributeName} = value
+    def ${attributeName.slice(2)}(self, ${value}):
+        self.${attributeName} = ${value}
 `;
 		generatedCode += setterMethod;
 
@@ -91,8 +91,8 @@ function generateGetterSetterMethods(pythonCode) {
 		generatedCode += getterMethod;
 
 		const setterMethod = `
-    def set_${attributeName}(self, value):
-        self.${attributeName} = value
+    def set_${attributeName}(self, ${value}):
+        self.${attributeName} = ${value}
 `;
 		generatedCode += setterMethod;
 		  }


### PR DESCRIPTION
In Python, private atributes starts with double underscore, not with single underscore.